### PR TITLE
Utility function to extract text from PDFs

### DIFF
--- a/pdf_utils.py
+++ b/pdf_utils.py
@@ -1,0 +1,21 @@
+import StringIO
+from pdfminer.pdfpage import PDFPage
+from pdfminer.converter import TextConverter
+from pdfminer.pdfinterp import PDFResourceManager, PDFPageInterpreter
+
+def convert_pdf_to_text(pdf_link):
+    resource_manager = PDFResourceManager()
+    output = StringIO.StringIO()
+    device = TextConverter(
+        resource_manager,
+        output,
+        codec='utf-8',
+    )
+    interpreter = PDFPageInterpreter(resource_manager, device)
+    file_handler = file(pdf_link, 'rb')
+    pages = PDFPage.get_pages(file_handler)
+
+    for page in pages:
+        interpreter.process_page(page)
+
+    return output.getvalue().strip('\n\t\r')

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pattern
 ipdb
 scrapy
 html2text
+pdfminer


### PR DESCRIPTION
This can be used when parsing documents for content items. When there
are PDF attachments in documents, we can use this utility to fetch the
data and include it in the corpus, so we have more information to train
LDA on.
