### PR TITLE
Consider the number of times a bigram occurs

### DIFF
--- a/gensim_engine.py
+++ b/gensim_engine.py
@@ -51,7 +51,7 @@ class GensimEngine:
                 if len(key.split("_")) > 1:
                     bigram_counter[key] += bigram.vocab[key]
 
-        found_bigrams = [bigram[0] for bigram in bigram_counter.most_common(number_of_bigrams)]
+        found_bigrams = [[bigram] * bigram_count for bigram, bigram_count in bigram_counter.most_common(number_of_bigrams)]
 
         return found_bigrams
 


### PR DESCRIPTION
Previously, any time we encountered a bigram, we would only
add one copy of it to the unigram lemmas.

Adding one copy for every occurence means bigrams and unigrams are
treated equally by the LDA algorithm.
