### PR TITLE
Treat stopwords as UTF8 bytestrings

### DIFF
--- a/gensim_engine.py
+++ b/gensim_engine.py
@@ -3,6 +3,7 @@ import csv
 import logging
 import re
 import sys
+import warnings
 from itertools import chain, repeat
 from operator import itemgetter
 from gensim import corpora, models
@@ -15,6 +16,11 @@ import pyLDAvis
 import pyLDAvis.gensim
 
 import gensim
+warnings.filterwarnings('error')
+
+
+NLTK_ENGLISH_STOPWORDS = [word.encode('utf8') for word in stopwords.words('english')]
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--nobigrams', dest='bigrams', action='store_false')
@@ -61,7 +67,7 @@ class GensimEngine:
         bigram_counter = Counter()
 
         for key in bigram.vocab.keys():
-            if key not in stopwords.words("english"):
+            if key not in NLTK_ENGLISH_STOPWORDS:
                 if len(key.split("_")) > 1:
                     bigram_counter[key] += bigram.vocab[key]
 


### PR DESCRIPTION
The NLTK stopwords are `unicode` strings, whereas the `lemmatize`
function always returns `str` (in this case, utf8 encoded bytes).
https://docs.python.org/2/howto/unicode.html#python-2-x-s-unicode-support

Mixing these up causes problems because to convert between them
python needs to assume an encoding, and the default encoding is ascii.

When we check if a bigram is in the list of stopwords, python never
accepts any with non-ascii characters in, eg `'interesting/JJ_\xc3\xa9mile/NN'`

By default, python will log this as a warning, such as:

``` python
>>> 'é' in [u'é']
__main__:1: UnicodeWarning: Unicode equal comparison failed to convert
both arguments to Unicode - interpreting them as being unequal
False
```

I've added the `filterwarnings` call to make this an error, and
converted all the stop words to `str`s.

This shouldn't change the output right now, because we currently
whitelist the bigrams.
