### PR TITLE
Combine multiple word sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,25 @@ engine.tag(untagged_documents)
 
 Each document is expected to be a list of dictionaries, where each dictionary
 has a `base_path` key and a `text` key.
+
+## Fetching new data
+
+### Import indexable content from the search API
+
+### Import PDF data
+
+### Combine all the data
+
+The python tool [CSVKit](https://csvkit.readthedocs.io/en/0.9.1/index.html) can be used to combine the separate CSVs into one:
+
+Note that because the columns are very wide, you will need to increase the default maximum field size:
+
+```
+csvjoin -c url all_audits_for_education.csv all_audits_for_education_with_pdf_data.csv > all_audits_for_education_with_pdf_and_indexable_content.csv --maxfieldsize [a big number]
+```
+
+The resulting CSV can then be passed to `data_import/combine_csv_columns.py` to merge everything into one "words" column.
+
+```
+python data_import/combine_csv_columns.py < all_audits_for_education_with_pdf_and_indexable_content.csv > all_audits_for_education_words.csv
+```

--- a/data_import/combine_csv_columns.py
+++ b/data_import/combine_csv_columns.py
@@ -1,0 +1,25 @@
+import csv
+import sys
+
+csv.field_size_limit(sys.maxsize)
+
+
+def format_value(value):
+    """
+    When scraping indexable content from the search API, we joined
+    organisation and topic titles with pipes. Since we are combining
+    all the columns together here we need to make sure these get treated as
+    separate words.
+    """
+    return value.replace('|', ' ')
+
+
+if __name__ == '__main__':
+    reader = csv.DictReader(sys.stdin)
+    writer = csv.DictWriter(sys.stdout, ('url', 'words'))
+    wordy_columns = set('title,description,content,topics,organisations,pdfdata'.split(','))
+    writer.writeheader()
+
+    for row in reader:
+        words = ' '.join([format_value(value) for key, value in row.iteritems() if key in wordy_columns])
+        writer.writerow(dict(url=row['url'], words=words))

--- a/data_import/import_indexable_content.py
+++ b/data_import/import_indexable_content.py
@@ -99,7 +99,7 @@ def extract_base_path(input_row):
     Extract the base path from a GOV.UK URL
     """
     try:
-        link = input_row['url']
+        link = input_row['url'].strip()
     except KeyError:
         raise KeyError('Input CSV should contain a column header "url"')
 


### PR DESCRIPTION
This combines the PDF text with the text we got from the search API, which includes titles, "indexable content", organisation titles, and "topic" titles (a small amount of documents are tagged to [GOV.UK topic pages](https://www.gov.uk/topic)).
