### PR TITLE
Only parse CLI options when run from the CLI

### DIFF
--- a/early_years_titles_descriptions.py
+++ b/early_years_titles_descriptions.py
@@ -1,6 +1,10 @@
 import csv
 import json
+import sys
 from gensim_engine import GensimEngine
+
+# Allow engine arguments to be passed on the command line
+args = sys.argv[1:] if __name__ == '__main__' else ()
 
 raw_documents = []
 
@@ -12,7 +16,7 @@ with open('input/early-years-titles-descriptions.csv', 'r') as f:
 print("Prepare documents")
 documents = [{'base_path': doc[0], 'text': doc[1]} for doc in raw_documents if len(doc) == 2 and doc[1] != '']
 
-engine = GensimEngine(documents, log=True, dictionary_path='input/dictionary.txt')
+engine = GensimEngine(documents, log=True, dictionary_path='input/dictionary.txt', args=args)
 engine.train(number_of_topics=5, passes=200)
 
 print("Print topics to file")

--- a/gensim_engine.py
+++ b/gensim_engine.py
@@ -15,11 +15,12 @@ import pyLDAvis.gensim
 
 import gensim
 
-parser = argparse.ArgumentParser(description=__doc__)
+parser = argparse.ArgumentParser()
 parser.add_argument('--nobigrams', dest='bigrams', action='store_false')
 
+
 class GensimEngine:
-    def __init__(self, documents, log=False, dictionary_path=None):
+    def __init__(self, documents, log=False, dictionary_path=None, args=()):
         """
         Documents is expected to be a list of dictionaries, where each element
         includes a `base_path` and `text`.
@@ -33,7 +34,7 @@ class GensimEngine:
         self.bigrams = []
         self.top_bigrams = []
         self.dictionary_path = dictionary_path
-        self.options = parser.parse_args()
+        self.options = parser.parse_args(args)
 
         with open('input/bigrams.csv', 'r') as f:
             reader = csv.reader(f)


### PR DESCRIPTION
- gensim_engine shouldn't interact with sys.argv directly
- scripts should only pass command line arguments if they are the entry
  point for the program

Originally I put all the parsing in gensim_engine because all of our
scripts worked the same way and none of them took special arguments.

This broke when we started using jupyter notebooks because everything
is running through the ipython kernel, so sys.argv contains other
arguments.
