### PR TITLE
Require pandas 0.18.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pandas==0.18.1
 nltk
 numpy
 lda
@@ -12,3 +13,4 @@ requests_cache
 BeautifulSoup
 pyLDAvis
 jupyter
+


### PR DESCRIPTION
0.19.0 of Pandas was released on 2nd October.

The previous version, 0.18.1 deprecated a sort_values method,
which pyLDAviz uses.
http://pandas.pydata.org/pandas-docs/version/0.18.1/whatsnew.html#deprecations

It looks like this was made an error in 0.19.0, so pyLDAviz throws an
exception like this:
```
Exporting visualisation to output/withpdf_vis.html
Traceback (most recent call last):
  File "train_lda.py", line 82, in <module>
    engine.visualise(args.vis_filename)
  File "/Users/matmoore/govuk/govuk-lda-tagger/gensim_engine.py", line 150, in visualise
    viz = pyLDAvis.gensim.prepare(self.ldamodel, self.corpus, self.dictionary)
  File "/Users/matmoore/.virtualenvs/lda/lib/python2.7/site-packages/pyLDAvis/gensim.py", line 110, in prepare
    return vis_prepare(**opts)
  File "/Users/matmoore/.virtualenvs/lda/lib/python2.7/site-packages/pyLDAvis/_prepare.py", line 398, in prepare
    token_table        = _token_table(topic_info, term_topic_freq, vocab, term_frequency)
  File "/Users/matmoore/.virtualenvs/lda/lib/python2.7/site-packages/pyLDAvis/_prepare.py", line 267, in _token_table
    term_ix.sort()
  File "/Users/matmoore/.virtualenvs/lda/lib/python2.7/site-packages/pandas/indexes/base.py", line 1703, in sort
    raise TypeError("cannot sort an Index object in-place, use "
TypeError: cannot sort an Index object in-place, use sort_values instead
```

Until this is fixed, lets just use the older version of Pandas.