### PR TITLE
Load corpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,13 +103,7 @@ The `train_lda.py` script provides a command line interface (CLI) to the GensimE
 Using the early years data from the HTML pages to derive topics, and tagging every document to those topics:
 
 ```
-train_lda.py input/early-years.csv --output-topics output/early_years_topics.csv --output-tags output/early_years_tagged_data.csv
-```
-
-Using the early years' audit content as training data and tagging the search API titles and descriptions of 700 documents:
-
-```
-train_lda.py input/early-years-titles-descriptions.csv --output-topics output/early_years_title_description_topics.csv --output-tags output/early_years_title_description_tagged_data.csv
+train_lda.py --output-topics output/early_years_topics.csv --output-tags output/early_years_tagged_data.csv import input/early-years.csv
 ```
 
 ### Using a curated dictionary
@@ -117,7 +111,7 @@ train_lda.py input/early-years-titles-descriptions.csv --output-topics output/ea
 Pass a curated dictionary using the `--input-dictionary` option.
 
 ```
-train_lda.py input/audits_with_content.csv --output-topics output/curated_early_years_topics.csv --input-dictionary input/dictionary.txt
+train_lda.py --output-topics output/curated_early_years_topics.csv import input/audits_with_content.csv --input-dictionary input/dictionary.txt
 ```
 
 ## Existing Data

--- a/corpus_building.py
+++ b/corpus_building.py
@@ -1,0 +1,132 @@
+import argparse
+import csv
+import logging
+import re
+import sys
+import warnings
+import os
+from itertools import chain, repeat
+from operator import itemgetter
+from gensim import corpora, models
+from gensim.utils import lemmatize
+from gensim.parsing.preprocessing import STOPWORDS
+from gensim.models import Phrases
+from nltk.corpus import stopwords
+from collections import Counter
+import pyLDAvis
+import pyLDAvis.gensim
+import phrasemachine
+
+import gensim
+
+
+NLTK_ENGLISH_STOPWORDS = [word.encode('utf8') for word in stopwords.words('english')]
+
+
+class CorpusReader(object):
+    """
+    Extract terms and phrases from raw text to run LDA on.
+    """
+    def __init__(self, include_bigrams=True, use_phrasemachine=False):
+        self.include_bigrams = include_bigrams
+        self.use_phrasemachine = use_phrasemachine
+
+        with open('input/bigrams.csv', 'r') as f:
+            reader = csv.reader(f)
+            self.top_bigrams = [bigram[0] for bigram in list(reader)]
+
+    def document_phrases(self, raw_text):
+        """
+        Extract some kind of n-grams from a document
+        """
+        if self.use_phrasemachine:
+            phrases = self._phrases_in_raw_text_via_phrasemachine(raw_text)
+        else:
+            phrases = self._phrases_in_raw_text_via_lemmatisation(raw_text)
+
+        return phrases
+
+    def fetch_document_bigrams(self, document_lemmas, number_of_bigrams=100):
+        """
+        Given a number of lemmas identifying a document, it calculates N bigrams
+        found in that document, where N=number_of_bigrams.
+        """
+        if not self.include_bigrams:
+            return []
+
+        bigram = Phrases()
+        bigram.add_vocab([document_lemmas])
+        bigram_counter = Counter()
+
+        for key in bigram.vocab.keys():
+            if key not in NLTK_ENGLISH_STOPWORDS:
+                if len(key.split("_")) > 1:
+                    bigram_counter[key] += bigram.vocab[key]
+
+        bigram_iterators = [
+            repeat(bigram, bigram_count)
+            for bigram, bigram_count
+            in bigram_counter.most_common(number_of_bigrams)
+        ]
+        found_bigrams = list(chain(*bigram_iterators))
+        known_bigrams = [bigram for bigram in found_bigrams if bigram in self.top_bigrams]
+
+        return known_bigrams
+
+    def build_corpus(self, documents, dictionary_path=None):
+        """
+        Build a corpus and dictionary from the input documents.
+
+        You can load an existing dictionary file to avoid computing it
+        from scratch when retraining the model on the same input.
+        """
+        print("Generating lemmas for each of the documents")
+        phrases = []
+        for document in documents:
+            raw_text = document['text'].lower()
+
+            phrases.append(self.document_phrases(raw_text))
+
+        if dictionary_path:
+            print("Load pre-existing dictionary from file")
+            dictionary = corpora.Dictionary.load_from_text(dictionary_path)
+        else:
+            print("Turn our tokenized documents into a id <-> term dictionary")
+            dictionary = corpora.Dictionary(phrases)
+
+        print("Convert tokenized documents into a document-term matrix")
+        return [dictionary.doc2bow(phrase) for phrase in phrases], dictionary
+
+    def _phrases_in_raw_text_via_phrasemachine(self, raw_text):
+        """
+        Builds a list of phrases from raw text using phrasemachine.
+        """
+        # This returns a Dictionary of counts
+        phrase_counts = phrasemachine.get_phrases(raw_text)['counts']
+
+        print("Found the following phrases: {}".format(phrase_counts))
+
+        phrases_in_document = []
+        for unique_phrase in phrase_counts:
+            # Fetch how many times this phrase occurred
+            phrase_count = phrase_counts[unique_phrase]
+
+            # Create N strings based on the count, since LDA will do the counts
+            phrases_for_phrase_count = [unique_phrase] * phrase_count
+
+            # Now that we have the phrase repeated, add them to the final
+            # list of phrases.
+            for phrase in phrases_for_phrase_count:
+                phrases_in_document.append(phrase)
+
+        return phrases_in_document
+
+    def _phrases_in_raw_text_via_lemmatisation(self, raw_text):
+        """
+        Builds a list of lemmas from raw text using lemmatization.
+        """
+        all_lemmas = lemmatize(raw_text, allowed_tags=re.compile('(NN|JJ)'), stopwords=STOPWORDS)
+        document_bigrams = self.fetch_document_bigrams(all_lemmas)
+        known_bigrams = [bigram for bigram in document_bigrams if bigram in self.top_bigrams]
+
+        return (all_lemmas + known_bigrams)

--- a/train_lda.py
+++ b/train_lda.py
@@ -7,16 +7,34 @@ import datetime
 from gensim_engine import GensimEngine
 from model_io import load_documents, export_topics, export_tags
 
-
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument(
-    'training_documents', metavar='FILENAME',
+subparsers = parser.add_subparsers(help='sub-commands')
+
+import_parser = subparsers.add_parser('import', help='Import a new dataset')
+import_parser.set_defaults(command='import')
+
+refine_parser = subparsers.add_parser('refine', help='Retrain an existing experiment')
+refine_parser.set_defaults(command='refine')
+
+import_parser.add_argument(
+    'training_documents', metavar='CSV',
     help='File containing the training documents'
 )
-parser.add_argument(
-    '--input-dictionary', dest='dictionary', metavar='FILENAME',
+import_parser.add_argument(
+    '--input-dictionary', dest='dictionary', metavar='DICTIONARY',
     help='A curated dictionary file. If not specified, the dictionary will be generated from the training documents.'
 )
+import_parser.add_argument(
+    '--nobigrams', dest='bigrams', action='store_false',
+    help="Don't include bigrams in the model's vocabulary."
+)
+
+refine_parser.add_argument(
+    'experiment', metavar='EXPERIMENT',
+    help='Name of a previous experiment, eg 2016-11-01_15-44-06_695357'
+)
+
+
 parser.add_argument(
     '--output-topics', dest='topics_filename', metavar='FILENAME',
     help='Save topics data to a file.'
@@ -25,10 +43,7 @@ parser.add_argument(
     '--output-tags', dest='tags_filename', metavar='FILENAME',
     help='Save tagged documents to a file.'
 )
-parser.add_argument(
-    '--nobigrams', dest='bigrams', action='store_false',
-    help="Don't include bigrams in the model's vocabulary."
-)
+
 parser.add_argument(
     '--numtopics', dest='number_of_topics', type=int, default=20,
     help="Number of topics to train"
@@ -53,18 +68,23 @@ parser.add_argument(
 if __name__ == '__main__':
     args = parser.parse_args()
 
-    print("Loading input file {}".format(args.training_documents))
-    training_documents = load_documents(args.training_documents)
+    if args.command == 'import':
+        print("Loading input file {}".format(args.training_documents))
+        training_documents = load_documents(args.training_documents)
+
+        engine = GensimEngine.from_documents(
+            training_documents,
+            log=True,
+            dictionary_path=args.dictionary,
+            include_bigrams=args.bigrams,
+            use_phrasemachine=args.use_phrasemachine
+        )
+
+    else:
+        print ("Loading experiment {}".format(args.experiment))
+        engine = GensimEngine.from_experiment(args.experiment, log=True)
 
     print("Training...")
-    engine = GensimEngine.from_documents(
-        training_documents,
-        log=True,
-        dictionary_path=args.dictionary,
-        include_bigrams=args.bigrams,
-        use_phrasemachine=args.use_phrasemachine
-    )
-
     experiment = engine.train(number_of_topics=args.number_of_topics, words_per_topic=args.words_per_topic, passes=args.passes)
 
     name = datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S_%f')

--- a/train_lda.py
+++ b/train_lda.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
     training_documents = load_documents(args.training_documents)
 
     print("Training...")
-    engine = GensimEngine(
+    engine = GensimEngine.from_documents(
         training_documents,
         log=True,
         dictionary_path=args.dictionary,


### PR DESCRIPTION
This is another refactor to pull all the corpus generation into a separate class.

With this, we can train multiple models on the same corpus without generating each time. I've changed the command line interface to use separate subcommands for this, which feels a bit clunky but we can change it if needed.

This is going to conflict with @carvil 's work, so I'll leave this open for comment, and rebase it on top of that tomorrow.