### PR TITLE
Add back TF-IDF weighting

### DIFF
--- a/corpus_building.py
+++ b/corpus_building.py
@@ -27,9 +27,10 @@ class CorpusReader(object):
     """
     Extract terms and phrases from raw text to run LDA on.
     """
-    def __init__(self, include_bigrams=True, use_phrasemachine=False):
+    def __init__(self, include_bigrams=True, use_phrasemachine=False, use_tfidf=False):
         self.include_bigrams = include_bigrams
         self.use_phrasemachine = use_phrasemachine
+        self.use_tfidf = use_tfidf
 
         with open('input/bigrams.csv', 'r') as f:
             reader = csv.reader(f)
@@ -95,7 +96,14 @@ class CorpusReader(object):
             dictionary = corpora.Dictionary(phrases)
 
         print("Convert tokenized documents into a document-term matrix")
-        return [dictionary.doc2bow(phrase) for phrase in phrases], dictionary
+        corpus = [dictionary.doc2bow(phrase) for phrase in phrases]
+
+        if self.use_tfidf:
+            tfidfmodel = gensim.models.TfidfModel(corpus)
+            corpus = tfidfmodel[corpus]
+
+
+        return corpus, dictionary
 
     def _phrases_in_raw_text_via_phrasemachine(self, raw_text):
         """

--- a/gensim_engine.py
+++ b/gensim_engine.py
@@ -43,12 +43,12 @@ class GensimEngine(object):
                 level=logging.INFO)
 
     @staticmethod
-    def from_documents(documents, log=False, dictionary_path=None, include_bigrams=True, use_phrasemachine=False):
+    def from_documents(documents, log=False, dictionary_path=None, include_bigrams=True, use_phrasemachine=False, use_tfidf=False):
         """
         Documents is expected to be a list of dictionaries, where each element
         includes a `base_path` and `text`.
         """
-        reader = CorpusReader(include_bigrams=include_bigrams, use_phrasemachine=use_phrasemachine)
+        reader = CorpusReader(include_bigrams=include_bigrams, use_phrasemachine=use_phrasemachine, use_tfidf=use_tfidf)
         corpus, dictionary = reader.build_corpus(documents, dictionary_path=dictionary_path)
         return GensimEngine(corpus, dictionary, log=log, corpus_reader=reader)
 

--- a/train_lda.py
+++ b/train_lda.py
@@ -64,7 +64,10 @@ parser.add_argument(
     '--use-phrasemachine', dest='use_phrasemachine', action='store_true',
     help="Use phrasemachine instead of lemmatization when building the dictionary."
 )
-
+parser.add_argument(
+    '--use-tfidf', dest='use_tfidf', action='store_true',
+    help="Weight terms in a document according to TF-IDF."
+)
 if __name__ == '__main__':
     args = parser.parse_args()
 
@@ -77,7 +80,8 @@ if __name__ == '__main__':
             log=True,
             dictionary_path=args.dictionary,
             include_bigrams=args.bigrams,
-            use_phrasemachine=args.use_phrasemachine
+            use_phrasemachine=args.use_phrasemachine,
+            use_tfidf=args.use_tfidf
         )
 
     else:


### PR DESCRIPTION
This was removed here:
https://github.com/alphagov/govuk-lda-tagger/commit/4d16eff24a3f0a7b9aede0e05035ba4bd6fc7430

We'd like to experiment with this again so that we can avoid looking at
terms that are common across the whole corpus (such as "early years")