### PR TITLE
Use corpus to generate tags

### DIFF
--- a/train_lda.py
+++ b/train_lda.py
@@ -97,7 +97,7 @@ if __name__ == '__main__':
 
     if args.tags_filename:
         print("Exporting tags to {}".format(args.tags_filename))
-        tags = engine.tag(training_documents)
+        tags = experiment.tag()
         export_tags(tags, args.tags_filename)
 
     if args.vis_filename:


### PR DESCRIPTION
This is an attempt to avoid re-parsing the raw text when we tag the documents to the LDA-generated topics.

We're not tagging any other documents once the model has been trained,
so we can just use the corpus we've already created, which can be saved
and loaded between experiments.