### PR TITLE
Ignore very frequent/infrequent terms

### DIFF
--- a/corpus_building.py
+++ b/corpus_building.py
@@ -27,10 +27,13 @@ class CorpusReader(object):
     """
     Extract terms and phrases from raw text to run LDA on.
     """
-    def __init__(self, include_bigrams=True, use_phrasemachine=False, use_tfidf=False):
+    def __init__(self, include_bigrams=True, use_phrasemachine=False, use_tfidf=False, no_below=5, no_above=0.5, keep_n=None):
         self.include_bigrams = include_bigrams
         self.use_phrasemachine = use_phrasemachine
         self.use_tfidf = use_tfidf
+        self.no_below = no_below
+        self.no_above = no_above
+        self.keep_n = keep_n
 
         with open('input/bigrams.csv', 'r') as f:
             reader = csv.reader(f)
@@ -94,6 +97,9 @@ class CorpusReader(object):
         else:
             print("Turn our tokenized documents into a id <-> term dictionary")
             dictionary = corpora.Dictionary(phrases)
+
+            # Filter out very (in)frequent words. This changes the id <-> term mapping.
+            dictionary.filter_extremes(no_below=self.no_below, no_above=self.no_above, keep_n=self.keep_n)
 
         print("Convert tokenized documents into a document-term matrix")
         corpus = [dictionary.doc2bow(phrase) for phrase in phrases]

--- a/gensim_engine.py
+++ b/gensim_engine.py
@@ -45,12 +45,12 @@ class GensimEngine(object):
                 level=logging.INFO)
 
     @staticmethod
-    def from_documents(documents, log=False, dictionary_path=None, include_bigrams=True, use_phrasemachine=False, use_tfidf=False):
+    def from_documents(documents, log=False, dictionary_path=None, **reader_kwargs):
         """
         Documents is expected to be a list of dictionaries, where each element
         includes a `base_path` and `text`.
         """
-        reader = CorpusReader(include_bigrams=include_bigrams, use_phrasemachine=use_phrasemachine, use_tfidf=use_tfidf)
+        reader = CorpusReader(**reader_kwargs)
         corpus, dictionary = reader.build_corpus(documents, dictionary_path=dictionary_path)
         document_metadata = [dict(base_path=doc['base_path']) for doc in documents]
         return GensimEngine(corpus, dictionary, log=log, corpus_reader=reader, document_metadata=document_metadata)

--- a/train_lda.py
+++ b/train_lda.py
@@ -28,7 +28,18 @@ import_parser.add_argument(
     '--nobigrams', dest='bigrams', action='store_false',
     help="Don't include bigrams in the model's vocabulary."
 )
-
+import_parser.add_argument(
+    '--no-below', dest='no_below', type=int, default=0,
+    help="Filter out words that occur less than this number of times in the corpus."
+)
+import_parser.add_argument(
+    '--no-above', dest='no_above', type=float, default=0.5,
+    help="Filter out words that make up more than this fraction of the corpus."
+)
+import_parser.add_argument(
+    '--keep-n', dest='keep_n', type=int, default=None,
+    help="Keep this many terms in the dictionary after filtering extremes."
+)
 refine_parser.add_argument(
     'experiment', metavar='EXPERIMENT',
     help='Name of a previous experiment, eg 2016-11-01_15-44-06_695357'
@@ -81,7 +92,10 @@ if __name__ == '__main__':
             dictionary_path=args.dictionary,
             include_bigrams=args.bigrams,
             use_phrasemachine=args.use_phrasemachine,
-            use_tfidf=args.use_tfidf
+            use_tfidf=args.use_tfidf,
+            no_below=args.no_below,
+            no_above=args.no_above,
+            keep_n=args.keep_n,
         )
 
     else:


### PR DESCRIPTION
By default `train_lda.py` will allow most (if not all) terms it extracts
from the corpus.

Use --no-below <number of occurences> to filter out rare terms

Use --no-above <fraction of corpus> to filter out very common terms, eg
"early" "years".

Use --keep-n <n> to trim the dictionary to the top n words after
filtering.

These options correspond to the gensim arguments with the same names:
https://radimrehurek.com/gensim/corpora/dictionary.html#gensim.corpora.dictionary.Dictionary.filter_extremes