### PR TITLE
Simplify CLI options

### DIFF
--- a/gensim_engine.py
+++ b/gensim_engine.py
@@ -89,7 +89,7 @@ class Experiment(object):
     """
     Each experiment contains a corpus of words and an LDA model of it
     """
-    DEFAULT_EXPERIMENT_PATH = os.path.join('output', 'models')
+    DEFAULT_EXPERIMENT_PATH = os.path.join('experiments')
 
     def __init__(self, model, corpus, dictionary, document_metadata):
         self.ldamodel = model                       # Trained LDA model
@@ -171,4 +171,4 @@ class Experiment(object):
 
     @staticmethod
     def _filename(path, experiment, suffix):
-        return os.path.join(path, '{}_{}'.format(experiment, suffix))
+        return os.path.join(path, experiment, 'models', suffix)


### PR DESCRIPTION
Previously, you had to specify some combination of `--output-tags`,
`--output-topics`, and `--vis-filename` to run `train_lda.py`, otherwise it
wouldn't generate any output.

This was really annoying, and none of these things are expensive to
generate, so now we just always generate them, and the filenames are all
optional.

`--use-lemmatisation` is now on by default, so you need to pass
`--no-lemmatiation` instead to disable it.

By default, everything is now saved to a subdirectory of `experiment/`.
When running an `import`, you can specify the name of this with
`--experiment`.

This means the thing can run with less options, eg:

    python train_lda.py --experiment foo input/foo.csv

or:

    python train_lda.py --numtopics 15 refine foo